### PR TITLE
Fixed boolean operators (and, or) and introduced wildcard() function

### DIFF
--- a/src/main/antlr4/gov/nasa/pds/api/engineering/lexer/Search.g4
+++ b/src/main/antlr4/gov/nasa/pds/api/engineering/lexer/Search.g4
@@ -4,10 +4,12 @@ query : queryTerm EOF ;
 queryTerm : comparison | group ;
 group : NOT? LPAREN expression RPAREN ;
 expression : andStatement | orStatement | queryTerm ;
-andStatement : queryTerm (AND queryTerm)+ ;
-orStatement : queryTerm (OR queryTerm)+ ;
-comparison : FIELD operator ( FIELD | NUMBER | STRINGVAL | VALUE ) ;
+andStatement : queryTerm AND queryTerm ;
+orStatement : queryTerm OR queryTerm ;
+comparison : FIELD operator ( NUMBER | STRINGVAL | wildcardFunc ) ;
 operator : EQ | NE | GT | GE | LT | LE ;
+
+wildcardFunc : ('WILDCARD' | 'wildcard') LPAREN STRINGVAL RPAREN ;
 
 
 NOT : 'not' ;
@@ -19,7 +21,6 @@ GE : 'ge' ;
 LT : 'lt' ;
 LE : 'le' ;
 
-
 LPAREN : '(' ;
 RPAREN : ')' ;
 
@@ -28,7 +29,6 @@ OR  : 'OR' | 'or' ;
 
 FIELD     : [A-Za-z_] [A-Za-z0-9_.:/]* ;
 STRINGVAL : '"' ~["\r\n]* '"' ;
-NUMBER :  ('-')? [0-9]* ('.' [0-9]*)?  ;
-VALUE : [!-~]+ ;
+NUMBER :  ('-')? [0-9]+ ('.' [0-9]*)?  ;
 
 WS : [ \t\r\n]+ -> skip ;

--- a/src/main/antlr4/gov/nasa/pds/api/engineering/lexer/Search.g4
+++ b/src/main/antlr4/gov/nasa/pds/api/engineering/lexer/Search.g4
@@ -4,8 +4,8 @@ query : queryTerm EOF ;
 queryTerm : comparison | group ;
 group : NOT? LPAREN expression RPAREN ;
 expression : andStatement | orStatement | queryTerm ;
-andStatement : queryTerm AND queryTerm ;
-orStatement : queryTerm OR queryTerm ;
+andStatement : queryTerm (AND queryTerm)+ ;
+orStatement : queryTerm (OR queryTerm)+ ;
 comparison : FIELD operator ( NUMBER | STRINGVAL | wildcardFunc ) ;
 operator : EQ | NE | GT | GE | LT | LE ;
 

--- a/src/test/java/api/pds/nasa/gov/api_search_query_lexer/TestParsing.java
+++ b/src/test/java/api/pds/nasa/gov/api_search_query_lexer/TestParsing.java
@@ -25,15 +25,16 @@ import gov.nasa.pds.api.engineering.lexer.SearchParser.OperatorContext;
 import gov.nasa.pds.api.engineering.lexer.SearchParser.OrStatementContext;
 import gov.nasa.pds.api.engineering.lexer.SearchParser.QueryContext;
 import gov.nasa.pds.api.engineering.lexer.SearchParser.QueryTermContext;
+import gov.nasa.pds.api.engineering.lexer.SearchParser.WildcardFuncContext;
 
 
-
-public class TestParsing implements ParseTreeListener,SearchListener
+public class TestParsing implements ParseTreeListener, SearchListener
 {
-	TerminalNode field=null, number=null, strval=null, value=null;
+	TerminalNode field=null, number=null, strval=null;
+	String wildcard=null;
 
 	@Test
-	public void isNumber()
+	public void testNumber()
 	{
 		String queryString = "lid eq 1234";
 		CodePointCharStream input = CharStreams.fromString(queryString);
@@ -44,13 +45,16 @@ public class TestParsing implements ParseTreeListener,SearchListener
         ParseTreeWalker walker = new ParseTreeWalker();
         walker.walk(this, tree);
         
+        Assertions.assertNotNull(this.field);
+        Assertions.assertEquals(this.field.getSymbol().getText(), "lid");
+        
         Assertions.assertNotEquals(this.number, null);
         Assertions.assertEquals(this.number.getSymbol().getText(), "1234");
        
 	}
 	
 	@Test
-	public void isStringVal()
+	public void testStringVal()
 	{
 		String queryString = "lid eq \"*text*\"";
 		CodePointCharStream input = CharStreams.fromString(queryString);
@@ -60,15 +64,19 @@ public class TestParsing implements ParseTreeListener,SearchListener
         ParseTree tree = par.query();
         ParseTreeWalker walker = new ParseTreeWalker();
         walker.walk(this, tree);
-        
-        Assertions.assertNotEquals(this.strval, null);
+
+        Assertions.assertNotNull(this.field);
+        Assertions.assertEquals(this.field.getSymbol().getText(), "lid");
+
+        Assertions.assertNotNull(this.strval);
         Assertions.assertEquals(this.strval.getSymbol().getText(), "\"*text*\"");
 	}
 	
+	
 	@Test
-	public void isValue()
+	public void testWildcard()
 	{
-		String queryString = "lid eq *text*";
+		String queryString = "lid eq wildcard(\"*text*\")";
 		CodePointCharStream input = CharStreams.fromString(queryString);
         SearchLexer lex = new SearchLexer(input);
         CommonTokenStream tokens = new CommonTokenStream(lex);
@@ -77,141 +85,185 @@ public class TestParsing implements ParseTreeListener,SearchListener
         ParseTreeWalker walker = new ParseTreeWalker();
         walker.walk(this, tree);
         
-        Assertions.assertNotEquals(this.value, null);
-        Assertions.assertEquals(this.value.getSymbol().getText(), "*text*");
+        Assertions.assertNotNull(this.field);
+        Assertions.assertEquals(this.field.getSymbol().getText(), "lid");
+
+        Assertions.assertNotNull(this.wildcard);
+        Assertions.assertEquals(this.wildcard, "\"*text*\"");
 	}
+
 	
-	@Test void isParsable()
+	@Test
+	void testTemporalRange()
 	{
-		String queryString = "lid eq text";
-		CodePointCharStream input = CharStreams.fromString(queryString);
+        String queryString = "(AAA gt \"2016-09-09\" and BBB lt \"2020-09-11\")";
+        CodePointCharStream input = CharStreams.fromString(queryString);
         SearchLexer lex = new SearchLexer(input);
         CommonTokenStream tokens = new CommonTokenStream(lex);
         SearchParser par = new SearchParser(tokens);
         ParseTree tree = par.query();
+
         ParseTreeWalker walker = new ParseTreeWalker();
         walker.walk(this, tree);
- 
-        Assertions.assertNotEquals(this.field, null);
-        Assertions.assertEquals(this.field.getSymbol().getText(), "text");
+        
+        // TODO: Parse
+        
 	}
 
-	@Override
-	public void visitTerminal(TerminalNode node) {
-		// TODO Auto-generated method stub
-		
-	}
-	@Override
-	public void visitErrorNode(ErrorNode node) {
-		// TODO Auto-generated method stub
-		
-	}
-	@Override
-	public void enterEveryRule(ParserRuleContext ctx) {
-		// TODO Auto-generated method stub
-	}
-	@Override
-	public void exitEveryRule(ParserRuleContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+	
+    @Override
+    public void enterQuery(QueryContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void enterQuery(QueryContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void exitQuery(QueryContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void exitQuery(QueryContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void enterQueryTerm(QueryTermContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void enterQueryTerm(QueryTermContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void exitQueryTerm(QueryTermContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void exitQueryTerm(QueryTermContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void enterGroup(GroupContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void enterGroup(GroupContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void exitGroup(GroupContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void exitGroup(GroupContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void enterExpression(ExpressionContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void enterExpression(ExpressionContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void exitExpression(ExpressionContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void exitExpression(ExpressionContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void enterAndStatement(AndStatementContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void enterAndStatement(AndStatementContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void exitAndStatement(AndStatementContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void exitAndStatement(AndStatementContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void enterOrStatement(OrStatementContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void enterOrStatement(OrStatementContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void exitOrStatement(OrStatementContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void exitOrStatement(OrStatementContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void enterComparison(ComparisonContext ctx)
+    {
+        this.field = ctx.FIELD();
+        this.number = ctx.NUMBER();
+        this.strval = ctx.STRINGVAL();
+    }
 
-	@Override
-	public void enterComparison(ComparisonContext ctx) {
-		// TODO Auto-generated method stub
-		this.field = ctx.FIELD(1);
-		this.number = ctx.NUMBER();
-		this.strval = ctx.STRINGVAL();
-		this.value = ctx.VALUE();
-	}
+    @Override
+    public void exitComparison(ComparisonContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void exitComparison(ComparisonContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void enterOperator(OperatorContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void enterOperator(OperatorContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void exitOperator(OperatorContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
 
-	@Override
-	public void exitOperator(OperatorContext ctx) {
-		// TODO Auto-generated method stub
-		
-	}
+    @Override
+    public void enterWildcardFunc(WildcardFuncContext ctx)
+    {
+        wildcard = ctx.getChild(2).getText();
+    }
+
+    @Override
+    public void exitWildcardFunc(WildcardFuncContext ctx)
+    {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public void enterEveryRule(ParserRuleContext arg0)
+    {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public void exitEveryRule(ParserRuleContext arg0)
+    {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public void visitErrorNode(ErrorNode arg0)
+    {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public void visitTerminal(TerminalNode arg0)
+    {
+        // TODO Auto-generated method stub
+        
+    }
+
+	
 }


### PR DESCRIPTION
## 🗒️ Summary
- Partially fixed broken logical operators (`and`, `or`) in query lexer / parser. 
- There is still a requirement that an expression with a logical operator has to be surrounded with `()`. For example, `(fieldA eq "abc" and fieldB eq "123)"`. To properly implement this, significant changes are required.
- Introduced `wildcard()` function to handle wildcard queries. For example, `fieldA eq wildcard("*bennu")`. I had to remove support for unquoted values / literals, including unquoted wildcards, because that breaks logical operators and parenthesis.


## Supported values
- String literals, including dates, have to be quoted: `fieldA eq "abc"`, `fieldB le "2016-05-07"`
- Numbers, can be unquoted: `fieldA eq 123`
- Wildcards, have to use wildcard() function with quoted value: `fieldA eq wildcard("*bennu")`

## ♻️ Related Issues
https://github.com/NASA-PDS/pds-api/issues/72
